### PR TITLE
Add debugging config 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",                        /* Redirect output structure to the directory. */
     "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
In order to be able to debug ts files, first of all we need to enable source map in tsconfig.

Then, there is some necessary steps to config the debug flow in IntelliJ.

1. Install Nodemon package locally. `npm i -g nodemon`
2. Go to IntelliJ -> top-right side -> Config run/debug
3. See img below
![Captura de pantalla 2020-03-20 a las 11 11 59](https://user-images.githubusercontent.com/40208332/77154889-de957280-6a9c-11ea-96be-3b9e968246be.png)

4. Apply and and check it.
